### PR TITLE
Use Bash IT custom path instead of symlinks

### DIFF
--- a/custom.aliases.bash
+++ b/custom.aliases.bash
@@ -1,5 +1,0 @@
-
-for custom in $BASH_IT/custom/aliases/*.bash; do
-	. $custom
-done
-

--- a/custom.bash
+++ b/custom.bash
@@ -1,5 +1,0 @@
-
-for custom in $BASH_IT/custom/lib/*.bash; do
-	. $custom
-done
-

--- a/custom.plugins.bash
+++ b/custom.plugins.bash
@@ -1,5 +1,0 @@
-
-for custom in $BASH_IT/custom/plugins/*.bash; do
-	. $custom
-done
-

--- a/install.bash
+++ b/install.bash
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-[[ -f $BASH_IT/aliases/custom.aliases.bash ]] || ln -s $BASH_IT/custom/custom.aliases.bash $BASH_IT/aliases/custom.aliases.bash
-[[ -f $BASH_IT/lib/custom.bash ]] || ln -s $BASH_IT/custom/custom.bash $BASH_IT/lib/custom.bash
-[[ -f $BASH_IT/plugins/custom.plugins.bash ]] || ln -s $BASH_IT/custom/custom.plugins.bash $BASH_IT/plugins/custom.plugins.bash
-

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-grep -q -F 'BASH_IT_CUSTOM' ~/.bash_profile ~/.bashrc || echo "BASH_IT_CUSTOM=$PWD\n\n$(cat ~/.bash_profile)" > ~/.bash_profile
+BASEDIR=$(dirname "$0")
+grep -q -F 'BASH_IT_CUSTOM' ~/.bash_profile ~/.bashrc || echo "BASH_IT_CUSTOM=$BASEDIR\n\n$(cat ~/.bash_profile)" > ~/.bash_profile

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+grep -q -F 'BASH_IT_CUSTOM' ~/.bash_profile ~/.bashrc || echo "\nBASH_IT_CUSTOM=$PWD\n" >> ~/.bashrc

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-grep -q -F 'BASH_IT_CUSTOM' ~/.bash_profile ~/.bashrc || echo "\nBASH_IT_CUSTOM=$PWD\n" >> ~/.bashrc
+grep -q -F 'BASH_IT_CUSTOM' ~/.bash_profile ~/.bashrc || echo "BASH_IT_CUSTOM=$PWD\n\n$(cat ~/.bash_profile)" > ~/.bash_profile


### PR DESCRIPTION
This PR switches to using bash-it's own way of using custom scripts. Just doing my due diligence.

Feel free to stick to your own symlink method. I'd love to know why you prefer the symlink method.

Ref: https://github.com/Bash-it/bash-it#custom-scripts-aliases-themes-and-functions